### PR TITLE
FEAT: Update rebirths currency in UI

### DIFF
--- a/TycoonStomper__v0.3.6.0-experimental/BaseManager.verse
+++ b/TycoonStomper__v0.3.6.0-experimental/BaseManager.verse
@@ -172,6 +172,10 @@ base<public>:=class<concrete>(SuperInaugurable, Rebirthable, Runtime, StringRetu
                 Base_Setup.HudConfig.OnSuccessfullPlayer(Player)
                 UI := currency_ui{Player:=Player,  Configs:=UIConfig, owner:=Self}
                 UI.Create()
+
+                #Updates rebirth currency in UI
+                UpdateAssociatedCurrencies(Player,Base_Setup.RebirthConfig.RebirthCurrencyID,PlayerStats.Rebirths,Base_Setup.PersistenceCore)
+
                 spawn{AwaitUIDestroy(UI)}
                 if:
                     Base_Setup.PersistUnlocks?

--- a/TycoonStomper__v0.3.6.0-experimental/cc/cClassesMain.verse
+++ b/TycoonStomper__v0.3.6.0-experimental/cc/cClassesMain.verse
@@ -38,6 +38,7 @@ rebirth_main<public>:=class<concrete>(Inaugurable, PlayerSpecificStringReturnabl
     @editable var RebirthButton <public>: button_device = button_device{}
     @editable var RebirthCashMultiplier<public> : float = 1.5
     @editable var RebirthCost <public> : float = 1000.0
+    @editable var RebirthCurrencyID <public> : int = 0  # Currency ID to show rebirths in UI
     @editable var RebirthCostCurrencyID <public> : int = 0
     @editable var RebirthCostMultiplier <public> : float = 1.5
     @editable var HudConfig <public> : hud_main = hud_main{OnFailedMessage := option{"Failed to rebirth you need [RebirthAmountNeeded]"}; OnSuccessMessage := option{"You have rebirthed! Every 100 now = [RebirthCashMultiplier]"}}


### PR DESCRIPTION
Rebirth stat already updates (core stats), but not in the UI, with this feature it will be updated in the UI to the RebirthCurrencyID you have previously chosen (in RebirthConfig) . You must have implemented corresponding currency settings.