### PR TITLE
Fixed Unlock bug.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,11 @@
 
  - Atleast 2 months of support for each beta version is my goal.
  - Experimental versions such as 0.3.5 are never officially `supported` by me.
+ - To view older versions simply click on the `tags` or `releases` tab.
 
 |  Version | Supported          |
 |  ------- | ------------------ |
+|  0.4.0   | :white_check_mark: |
 |  0.3.6   | :white_check_mark: |
 |  0.3.5   | :x:                |
 |  0.3.2   | :x:  |

--- a/TycoonStomperUnstableV0_4_0/Purchaseables/z_superclass.verse
+++ b/TycoonStomperUnstableV0_4_0/Purchaseables/z_superclass.verse
@@ -395,9 +395,9 @@ purchaseable<public>:=class<abstract>(Detailable, Hostable, SuperInaugurable, Re
             I -> ItemSet:UnlockTheseItems
         do:
             if:
-                PurchaseableData := FetchPurchaseableFromPtypeDex[ItemSet.Type, Base, I]
+                PurchaseableData := FetchPurchaseableFromPtypeDex[ItemSet.Type, Base, ItemSet.Index]
             then:
-                PurchaseableData(0).Unlock
+                PurchaseableData(0).Unlock()
             else:
                 GlobalSuperlog("")
                 set anyfailures = true; set failures += 1


### PR DESCRIPTION
UnlockDependents(Base:base):tuple(int, logic)=
        #Not using the decides / transacts effects so we dont rollback all the other unlocks that were successful.
        var anyfailures:logic=false
        var failures:int=0
        for:
            I -> ItemSet:UnlockTheseItems
        do:
            if:
                Print("Index {ItemSet.Index}")
                PurchaseableData := FetchPurchaseableFromPtypeDex[ItemSet.Type, Base, ItemSet.Index]
            then:
                Print("UNLOCKING!")
                PurchaseableData(0).Unlock()
                Print("UNLOCKED")
            else:
                GlobalSuperlog("")
                set anyfailures = true; set failures += 1
                UnlockFailure(ItemSet.Index, ItemSet.Type.ToStr())
        (failures, anyfailures)